### PR TITLE
Added alternative variable "g:bclose_no_plugin_maps" to disable mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The reason for adding it here is to be able to add it to an existing Janus bundl
 
 ## Bindings
 
-BClose binds `<Leader>bd` to `:Bclose` unless `g:bclose_no_plugin_maps` exists and is `true`.
+BClose binds `<Leader>bd` to `:Bclose` unless `g:bclose_no_plugin_maps` or `g:no_plugin_maps` is set to `true`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The reason for adding it here is to be able to add it to an existing Janus bundl
 
 ## Bindings
 
-BClose binds `<Leader>bd` to `:Bclose` unless `g:no_plugin_maps` exists and is `true`.
+BClose binds `<Leader>bd` to `:Bclose` unless `g:bclose_no_plugin_maps` exists and is `true`.
 
 ## Contributing
 

--- a/plugin/bclose.vim
+++ b/plugin/bclose.vim
@@ -70,6 +70,11 @@ function! s:Bclose(bang, buffer)
   execute wcurrent.'wincmd w'
 endfunction
 command! -bang -complete=buffer -nargs=? Bclose call <SID>Bclose('<bang>', '<args>')
-if !exists ("g:bclose_no_plugin_maps") || !g:bclose_no_plugin_maps
-  nnoremap <silent> <Leader>bd :Bclose<CR>
+
+if exists ("g:bclose_no_plugin_maps") &&  g:bclose_no_plugin_maps
+    "do nothing
+elseif exists ("g:no_plugin_maps") &&  g:no_plugin_maps
+    "do nothing
+else
+     nnoremap <silent> <Leader>bd :Bclose<CR>
 endif

--- a/plugin/bclose.vim
+++ b/plugin/bclose.vim
@@ -70,6 +70,6 @@ function! s:Bclose(bang, buffer)
   execute wcurrent.'wincmd w'
 endfunction
 command! -bang -complete=buffer -nargs=? Bclose call <SID>Bclose('<bang>', '<args>')
-if !exists ("g:no_plugin_maps") || !g:no_plugin_maps
+if !exists ("g:bclose_no_plugin_maps") || !g:bclose_no_plugin_maps
   nnoremap <silent> <Leader>bd :Bclose<CR>
 endif


### PR DESCRIPTION
As the title says. "no_plugin_maps" is already a variable for Vim and that could lead to confusion and unexpected behaviors, so I added another variable to disable the `<leader>bd` mapping.